### PR TITLE
Update PApplet.java

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -11695,6 +11695,31 @@ public class PApplet implements PConstants {
   public PShape createShape(int kind, float... p) {
     return g.createShape(kind, p);
   }
+  
+  public PShape createShape(int kind, float... p) {
+    PShape shape;
+    if (kind == ELLIPSE) {
+        if (g.shapeMode == CORNER) {
+            shape = g.createShape(ELLIPSE, p[0], p[1], p[2], p[3]);
+        } else if (g.shapeMode == CENTER) {
+            shape = g.createShape(ELLIPSE, p[0] + p[2]/2, p[1] + p[3]/2, p[2], p[3]);
+        } else {
+            throw new RuntimeException("Unsupported shape mode: " + g.shapeMode);
+        }
+    } else if (kind == RECT) {
+        if (g.shapeMode == CORNER) {
+            shape = g.createShape(RECT, p[0], p[1], p[2], p[3]);
+        } else if (g.shapeMode == CENTER) {
+            shape = g.createShape(RECT, p[0] - p[2]/2, p[1] - p[3]/2, p[2], p[3]);
+        } else {
+            throw new RuntimeException("Unsupported shape mode: " + g.shapeMode);
+        }
+    } else {
+        shape = g.createShape(kind, p);
+    }
+    return shape;
+}
+
 
 
   /**


### PR DESCRIPTION
shapeMode() only works with loadShape(), not createShape() #5367

This modified createShape() method takes the shapeMode into account for ELLIPSE and RECT. If the shapeMode is CORNER, the shape is created with the given parameters. If the shapeMode is CENTER, the shape is created with the center of the shape at the given coordinates. For other shape kinds, the original createShape() method is used.

After making this modification to the PGraphics class, you can then rebuild the Processing library and use the modified library in your project to create shapes using createShape() with shapeMode affecting the shape creation.